### PR TITLE
Add POS-5890 profile

### DIFF
--- a/data/profile/POS-5890.yml
+++ b/data/profile/POS-5890.yml
@@ -1,0 +1,89 @@
+---
+POS-5890:
+  name: POS5890 Series
+  vendor: Zjiang
+  inherits: simple
+  notes: >
+      POS-5890 thermal printer series, also marketed under various other names.
+  codePages:
+    0: CP437
+    1: CP932
+    2: CP850
+    3: CP860
+    4: CP863
+    5: CP865
+    # West Europe
+    6: Unknown
+    # Greek
+    7: Unknown
+    # Hebrew
+    8: Unknown
+    # East Europe
+    9: Unknown
+    # Iran
+    10: Unknown
+    16: CP1252
+    17: CP866
+    18: CP852
+    19: CP858
+    # Iran II
+    20: Unknown
+    # Latvian
+    21: Unknown
+    # Arabic
+    22: Unknown
+    # PT151, 1251
+    23: Unknown
+    24: CP747
+    25: CP1257
+    27: CP1258
+    28: CP864
+    # Hebrew
+    31: Unknown
+    32: CP1255
+    50: CP437
+    52: CP437
+    53: CP858
+    54: CP852
+    55: CP860
+    56: CP861
+    57: CP863
+    58: CP865
+    59: CP866
+    60: CP855
+    61: CP857
+    62: CP862
+    63: CP864
+    64: CP737
+    65: CP851
+    66: CP869
+    68: CP772
+    69: CP774
+    71: CP1252
+    72: CP1250
+    73: CP1251
+    74: CP3840
+    76: CP3843
+    77: CP3844
+    78: CP3845
+    79: CP3846
+    80: CP3847
+    81: CP3848
+    83: CP2001
+    84: CP3001
+    85: CP3002
+    86: CP3011
+    87: CP3012
+    88: CP3021
+    89: CP3041
+    90: CP1253
+    91: CP1254
+    92: CP1256
+    93: CP720
+    94: CP1258
+    95: CP775
+    # Thai 2
+    96: Unknown
+    # Thai
+    255: Unknown
+...

--- a/dist/capabilities.json
+++ b/dist/capabilities.json
@@ -395,6 +395,112 @@
             "notes": "",
             "vendor": "PBM"
         },
+        "POS-5890": {
+            "codePages": {
+                "0": "CP437",
+                "1": "CP932",
+                "2": "CP850",
+                "3": "CP860",
+                "4": "CP863",
+                "5": "CP865",
+                "6": "Unknown",
+                "7": "Unknown",
+                "8": "Unknown",
+                "9": "Unknown",
+                "10": "Unknown",
+                "16": "CP1252",
+                "17": "CP866",
+                "18": "CP852",
+                "19": "CP858",
+                "20": "Unknown",
+                "21": "Unknown",
+                "22": "Unknown",
+                "23": "Unknown",
+                "24": "CP747",
+                "25": "CP1257",
+                "27": "CP1258",
+                "28": "CP864",
+                "31": "Unknown",
+                "32": "CP1255",
+                "50": "CP437",
+                "52": "CP437",
+                "53": "CP858",
+                "54": "CP852",
+                "55": "CP860",
+                "56": "CP861",
+                "57": "CP863",
+                "58": "CP865",
+                "59": "CP866",
+                "60": "CP855",
+                "61": "CP857",
+                "62": "CP862",
+                "63": "CP864",
+                "64": "CP737",
+                "65": "CP851",
+                "66": "CP869",
+                "68": "CP772",
+                "69": "CP774",
+                "71": "CP1252",
+                "72": "CP1250",
+                "73": "CP1251",
+                "74": "CP3840",
+                "76": "CP3843",
+                "77": "CP3844",
+                "78": "CP3845",
+                "79": "CP3846",
+                "80": "CP3847",
+                "81": "CP3848",
+                "83": "CP2001",
+                "84": "CP3001",
+                "85": "CP3002",
+                "86": "CP3011",
+                "87": "CP3012",
+                "88": "CP3021",
+                "89": "CP3041",
+                "90": "CP1253",
+                "91": "CP1254",
+                "92": "CP1256",
+                "93": "CP720",
+                "94": "CP1258",
+                "95": "CP775",
+                "96": "Unknown",
+                "255": "Unknown"
+            },
+            "colors": {
+                "0": "black"
+            },
+            "features": {
+                "barcodeB": false,
+                "bitImageColumn": false,
+                "bitImageRaster": true,
+                "graphics": false,
+                "highDensity": true,
+                "pdf417Code": false,
+                "pulseBel": false,
+                "pulseStandard": true,
+                "qrCode": false,
+                "starCommands": false
+            },
+            "fonts": {
+                "0": {
+                    "columns": 42,
+                    "name": "Font A"
+                },
+                "1": {
+                    "columns": 56,
+                    "name": "Font B"
+                }
+            },
+            "media": {
+                "width": {
+                    "mm": "Unknown",
+                    "pixels": "Unknown"
+                }
+            },
+            "name": "POS5890 Series",
+            "notes": "POS-5890 thermal printer series, also marketed under various other names.\n",
+            "vendor": "Zjiang"
+        },
         "SP2000": {
             "codePages": {
                 "0": "CP437",

--- a/dist/capabilities.yml
+++ b/dist/capabilities.yml
@@ -322,6 +322,103 @@ profiles:
     name: "P822D"
     notes: ""
     vendor: "PBM"
+  POS-5890:
+    codePages:
+      0: "CP437"
+      1: "CP932"
+      2: "CP850"
+      3: "CP860"
+      4: "CP863"
+      5: "CP865"
+      6: "Unknown"
+      7: "Unknown"
+      8: "Unknown"
+      9: "Unknown"
+      10: "Unknown"
+      16: "CP1252"
+      17: "CP866"
+      18: "CP852"
+      19: "CP858"
+      20: "Unknown"
+      21: "Unknown"
+      22: "Unknown"
+      23: "Unknown"
+      24: "CP747"
+      25: "CP1257"
+      27: "CP1258"
+      28: "CP864"
+      31: "Unknown"
+      32: "CP1255"
+      50: "CP437"
+      52: "CP437"
+      53: "CP858"
+      54: "CP852"
+      55: "CP860"
+      56: "CP861"
+      57: "CP863"
+      58: "CP865"
+      59: "CP866"
+      60: "CP855"
+      61: "CP857"
+      62: "CP862"
+      63: "CP864"
+      64: "CP737"
+      65: "CP851"
+      66: "CP869"
+      68: "CP772"
+      69: "CP774"
+      71: "CP1252"
+      72: "CP1250"
+      73: "CP1251"
+      74: "CP3840"
+      76: "CP3843"
+      77: "CP3844"
+      78: "CP3845"
+      79: "CP3846"
+      80: "CP3847"
+      81: "CP3848"
+      83: "CP2001"
+      84: "CP3001"
+      85: "CP3002"
+      86: "CP3011"
+      87: "CP3012"
+      88: "CP3021"
+      89: "CP3041"
+      90: "CP1253"
+      91: "CP1254"
+      92: "CP1256"
+      93: "CP720"
+      94: "CP1258"
+      95: "CP775"
+      96: "Unknown"
+      255: "Unknown"
+    colors:
+      0: "black"
+    features:
+      barcodeB: false
+      bitImageColumn: false
+      bitImageRaster: true
+      graphics: false
+      highDensity: true
+      pdf417Code: false
+      pulseBel: false
+      pulseStandard: true
+      qrCode: false
+      starCommands: false
+    fonts:
+      0:
+        columns: 42
+        name: "Font A"
+      1:
+        columns: 56
+        name: "Font B"
+    media:
+      width:
+        mm: "Unknown"
+        pixels: "Unknown"
+    name: "POS5890 Series"
+    notes: "POS-5890 thermal printer series, also marketed under various other names.\n"
+    vendor: "Zjiang"
   SP2000:
     codePages:
       0: "CP437"


### PR DESCRIPTION
This pull request adds a POS-5890 profile to the database.

This common printer from Zjiang is sold under many names, and is one of the cheapest printers on the market.

- Feature support is based on the `simple` profile, since Epson's new graphics commands, QR codes, etc, are all unavailable.
- The language support compares well to other printers, other than issues with Vietnamese (no TCVN-3 code page is available, while CP1258 is present, but the printer does not compose the characters) 

Output of encoding test from `escpos-php` below:

![2017-01-pos-5890-1](https://cloud.githubusercontent.com/assets/2080552/22174187/589b4a2c-e02c-11e6-972e-2e035e529b85.png)
![2017-01-pos-5890-2](https://cloud.githubusercontent.com/assets/2080552/22174171/c468a34a-e02b-11e6-9662-d1d9500997c3.png)
![2017-01-pos-5890-3](https://cloud.githubusercontent.com/assets/2080552/22174172/c46a032a-e02b-11e6-9c21-93f4b5a24a2c.png)

Issue reference:

- #13
