### PR TITLE
Add Aures OCD-300 profile

### DIFF
--- a/data/profile/OCD-300.yml
+++ b/data/profile/OCD-300.yml
@@ -1,0 +1,43 @@
+---
+OCD-300:
+  name: Aures OCP-300 Customer Display
+  vendor: Aures
+  inherits: simple
+  features:
+    bitImageRaster: false
+    bitImageColumn: false
+  fonts:
+    0:
+      name: Font A
+      columns: 20
+  notes: >
+    This is a two-line, ESC/POS-aware customer display from Aures. It has some
+    graphics support via vendor-provided tools, but is otherwise text-only.
+  codePages:
+    0: CP437
+    # Katakana (for Japan)
+    1: CP932
+    2: CP850
+    3: CP860
+    4: CP863
+    5: CP865
+    # Slawie
+    6: Unknown
+    # Russia
+    7: Unknown
+    # Greek
+    8: Unknown
+    9: CP852
+    10: CP862
+    11: CP866
+    12: CP1251
+    13: CP1254
+    14: CP1255
+    15: CP1257
+    16: CP1252
+    17: CP1253
+    18: CP1250
+    19: CP858
+    # Arabic
+    20: Unknown
+...

--- a/dist/capabilities.json
+++ b/dist/capabilities.json
@@ -286,6 +286,61 @@
         }
     },
     "profiles": {
+        "OCD-300": {
+            "codePages": {
+                "0": "CP437",
+                "1": "CP932",
+                "2": "CP850",
+                "3": "CP860",
+                "4": "CP863",
+                "5": "CP865",
+                "6": "Unknown",
+                "7": "Unknown",
+                "8": "Unknown",
+                "9": "CP852",
+                "10": "CP862",
+                "11": "CP866",
+                "12": "CP1251",
+                "13": "CP1254",
+                "14": "CP1255",
+                "15": "CP1257",
+                "16": "CP1252",
+                "17": "CP1253",
+                "18": "CP1250",
+                "19": "CP858",
+                "20": "Unknown"
+            },
+            "colors": {
+                "0": "black"
+            },
+            "features": {
+                "barcodeB": false,
+                "bitImageColumn": false,
+                "bitImageRaster": false,
+                "graphics": false,
+                "highDensity": true,
+                "pdf417Code": false,
+                "pulseBel": false,
+                "pulseStandard": true,
+                "qrCode": false,
+                "starCommands": false
+            },
+            "fonts": {
+                "0": {
+                    "columns": 20,
+                    "name": "Font A"
+                }
+            },
+            "media": {
+                "width": {
+                    "mm": "Unknown",
+                    "pixels": "Unknown"
+                }
+            },
+            "name": "Aures OCP-300 Customer Display",
+            "notes": "This is a two-line, ESC/POS-aware customer display from Aures. It has some graphics support via vendor-provided tools, but is otherwise text-only.\n",
+            "vendor": "Aures"
+        },
         "P822D": {
             "codePages": {
                 "0": "CP437",

--- a/dist/capabilities.yml
+++ b/dist/capabilities.yml
@@ -222,6 +222,54 @@ encodings:
     name: "Unknown"
     notes: "Code page that has not yet been identified."
 profiles:
+  OCD-300:
+    codePages:
+      0: "CP437"
+      1: "CP932"
+      2: "CP850"
+      3: "CP860"
+      4: "CP863"
+      5: "CP865"
+      6: "Unknown"
+      7: "Unknown"
+      8: "Unknown"
+      9: "CP852"
+      10: "CP862"
+      11: "CP866"
+      12: "CP1251"
+      13: "CP1254"
+      14: "CP1255"
+      15: "CP1257"
+      16: "CP1252"
+      17: "CP1253"
+      18: "CP1250"
+      19: "CP858"
+      20: "Unknown"
+    colors:
+      0: "black"
+    features:
+      barcodeB: false
+      bitImageColumn: false
+      bitImageRaster: false
+      graphics: false
+      highDensity: true
+      pdf417Code: false
+      pulseBel: false
+      pulseStandard: true
+      qrCode: false
+      starCommands: false
+    fonts:
+      0:
+        columns: 20
+        name: "Font A"
+    media:
+      width:
+        mm: "Unknown"
+        pixels: "Unknown"
+    name: "Aures OCP-300 Customer Display"
+    notes: "This is a two-line, ESC/POS-aware customer display from Aures. It has\
+      \ some graphics support via vendor-provided tools, but is otherwise text-only.\n"
+    vendor: "Aures"
   P822D:
     codePages:
       0: "CP437"


### PR DESCRIPTION
New printer profile.

Tested that this makes currency symbols available on this display.

```php
<?php
require __DIR__ . '/autoload.php';
use Mike42\Escpos\PrintConnectors\FilePrintConnector;
use Mike42\Escpos\CapabilityProfile;
use Mike42\Escpos\Printer;

$connector = new FilePrintConnector("/dev/ttyACM0");
$profile = CapabilityProfile::load("OCD-300");
$printer = new Printer($connector, $profile);

$printer -> initialize();
$printer -> selectCharacterTable(0);
$printer -> text("Hello World!\n€ ¥ $\n");

$printer -> close();
```

And cycling through languages works on this profile as well (Vietnamese unavailable, otherwise pretty good).

```php
include(__DIR__ . "/example/resources/character-encoding-test-strings.inc");
foreach($inputsOk as $str) {
  // initialize() does not explicity set code page
  $printer -> initialize();
  $printer -> selectCharacterTable(0);
  $printer -> text($str);
  usleep(500000);
}
```

Note that `ESC @` (initialize) clears the screen, but that a separate command to reset to code page 0 must be sent on this device.

Issue reference:

- #22