### PR TITLE
Added Initial Profile for Rongta RP332 Thermal Printer

### DIFF
--- a/data/profile/RP332.yml
+++ b/data/profile/RP332.yml
@@ -34,7 +34,7 @@ RP332:
     dpi: 203
   codePages:
     0: CP437
-    1: Katakana
+    1: KATAKANA
     2: CP850
     3: CP860
     4: CP863

--- a/data/profile/RP332.yml
+++ b/data/profile/RP332.yml
@@ -1,0 +1,82 @@
+---
+RP332:
+  name: RP332
+  vendor: Rongta
+  inherits: default
+  notes: >
+      A low-cost ESC/POS thermal printer from Rongta with support for
+      80mm and 58mm paper (defaulting to 80mm). Supports USB, serial,
+      and Ethernet-based connections.
+  features:
+    bitImageRaster: true
+    bitImageColumn: true
+    graphics: false
+    qrCode: true
+    highDensity: false
+    paperFullCut: true
+    paperPartCut: false
+  colors:
+    0: black
+  fonts:
+    0:
+      name: Font A
+      columns: 42
+    1:
+      name: Font B
+      columns: 56
+    3:
+      name: Chinese
+      columns: 21
+  media:
+    width:
+      mm: 72
+      pixels: Unknown
+    dpi: 203
+  codePages:
+    0: CP437
+    1: Katakana
+    2: CP850
+    3: CP860
+    4: CP863
+    5: CP865
+    6: CP1251
+    7: CP866
+    # 8: MIK[Cyrillic/Bulgarian]
+    8: Unknown
+    15: CP862
+    16: CP1252
+    17: CP1253
+    18: CP852
+    19: CP858
+    # 20: Iran II
+    20: Unknown
+    # 21: Latvian
+    21: Unknown
+    22: CP864
+    23: ISO_8859-1
+    24: CP737
+    25: CP1257
+    # 26: Thai
+    26: Unknown
+    27: CP720
+    28: CP855
+    29: CP857
+    30: CP1250
+    31: CP775
+    32: CP1254
+    34: CP1256
+    35: CP1258
+    36: ISO_8859-2
+    37: ISO_8859-3
+    38: ISO_8859-4
+    39: ISO_8859-5
+    40: ISO_8859-6
+    41: ISO_8859-7
+    42: ISO_8859-8
+    43: ISO_8859-9
+    44: ISO_8859-15
+    # 45: Thai2
+    45: Unknown
+    46: CP856
+    47: CP874
+...

--- a/data/profile/TM-T70-SA.yml
+++ b/data/profile/TM-T70-SA.yml
@@ -11,24 +11,25 @@ TM-T70-SA:
   inherits: TM-T70
   fonts:
     0:
-      name: Font A # 12x24
+      name: Font A  # 12x24
       columns: 48
     1:
-      name: Font B # 9x17
+      name: Font B  # 9x17
       columns: 64
     97:
-      name: Special Font A # 12x24
+      name: Special Font A  # 12x24
       columns: 48
     98:
-      name: Special Font B # 9x24
+      name: Special Font B  # 9x24
       columns: 64
   media:
     width:
-      mm: 79.5 # paper width +/- 0.5mm, printable width 72mm
+      mm: 79.5  # paper width +/- 0.5mm, printable width 72mm
       pixels: 576
     dpi: 203
   codePages:
-  # https://download4.epson.biz/sec_pubs/pos/reference_en/charcode/supported_codepage.html
+    # https://download4.epson.biz
+    #  /sec_pubs/pos/reference_en/charcode/supported_codepage.html
     0: CP437        # USA, Standard Europe
     20: Unknown     # Thai Character Code 42
     21: CP874       # Thai Character Code 11

--- a/data/profile/TM-T70.yml
+++ b/data/profile/TM-T70.yml
@@ -24,18 +24,19 @@ TM-T70:
     0: black
   fonts:
     0:
-      name: Font A # 12x24
+      name: Font A  # 12x24
       columns: 42
     1:
-      name: Font B # 9x17
+      name: Font B  # 9x17
       columns: 56
   media:
     width:
-      mm: 79.5 # paper width +/- 0.5mm, printable width 72.2mm
+      mm: 79.5  # paper width +/- 0.5mm, printable width 72.2mm
       pixels: 512
     dpi: 180
   codePages:
-  # https://download4.epson.biz/sec_pubs/pos/reference_en/charcode/supported_codepage.html
+    # https://download4.epson.biz
+    # /sec_pubs/pos/reference_en/charcode/supported_codepage.html
     0: CP437        # USA, Standard Europe
     1: CP932        # Katakana
     2: CP850        # Multilingual


### PR DESCRIPTION
Added initial profile for the Rongta RP332 thermal printer. Closes #100.

## Notes

- The information provided in this profile reflects [the technical specifications provided by Rongta](https://www.rongtatech.com/rp332-3inch-thermal-receipt-printer_p15.html), information provided in printer test page (image attached), and some information that I derived by testing certain printer features (e.g., `bitImageRaster` and `paperPartCut`).
- This is my first experience working with ESC/POS printers, so if there's anything I can do to better capture or test printer specifications and features for this database, please let me know (the feedback would be greatly appreciated)!

## Printer Test Page Sample (Printed 2026-02-14)

![Rongta RP332 Printer Test Page 20260214](https://github.com/user-attachments/assets/cf241628-a5db-4b8f-838f-84a6b8a44a1e)