### PR TITLE
Add YHDAA YHD-8390 thermal printer profile

### DIFF
--- a/data/profile/YHD-8390.yml
+++ b/data/profile/YHD-8390.yml
@@ -1,0 +1,73 @@
+---
+YHD-8390:
+  name: YHD-8390
+  vendor: YHDAA Shenzhen Yuhengda Technology Co., Ltd.
+  inherits: simple
+  notes: >
+    YHDAA YHD-8390 thermal printer profile
+
+    Codepage changing most likely work only
+    with the factory/vendor provided software.
+  features:
+    barcodeA: true # CODABAR, CODE39,                  EAN8, EAN13, ITF, UPC-A, UPC-E
+    barcodeB: true # CODABAR, CODE39, CODE93, CODE128, EAN8, EAN13, ITF, UPC-A, UPC-E
+    qrCode: true
+    pdf417Code: true
+    bitImageRaster: true
+    bitImageColumn: true
+    graphics: false
+    starCommands: false
+    highDensity: true
+    pulseStandard: true
+    pulseBel: false
+    paperFullCut: false
+    paperPartCut: true
+  colors:
+    0: black
+  fonts:
+    0:
+      name: Font A
+      columns: 48
+    1:
+      name: Font B
+      columns: 64
+  media:
+    width:
+      mm: 80
+      pixels: 640
+    dpi: 203
+  codePages:
+    0: CP437
+    1: KATAKANA
+    2: CP850
+    3: CP860
+    4: CP863
+    5: CP865
+    6: Unknown  # West Europe
+    7: Unknown  # Greek
+    8: Unknown  # Hebrew
+    9: Unknown  # East Europe
+    10: Unknown # Iran
+    11: CP1252
+    12: CP866
+    13: CP852
+    14: CP858
+    15: Unknown # Iran II
+    16: Unknown # Latvian
+    17: Unknown # Arabic
+    18: CP1251
+    19: Unknown # CP747
+    20: CP1257
+    21: Unknown # Vietnam
+    22: CP864
+    23: CP1001
+    24: CP857
+    25: CP862
+    26: Unknown # CP928
+    27: CP869
+    28: CP851
+    29: CP737
+    30: CP871
+    31: CP1256
+    32: CP1258
+...

--- a/data/profile/YHD-8390.yml
+++ b/data/profile/YHD-8390.yml
@@ -9,8 +9,8 @@ YHD-8390:
     Codepage changing most likely work only
     with the factory/vendor provided software.
   features:
-    barcodeA: true # CODABAR, CODE39,                  EAN8, EAN13, ITF, UPC-A, UPC-E
-    barcodeB: true # CODABAR, CODE39, CODE93, CODE128, EAN8, EAN13, ITF, UPC-A, UPC-E
+    barcodeA: true # CODABAR,CODE39,               EAN8,EAN13,ITF,UPC-A,UPC-E
+    barcodeB: true # CODABAR,CODE39,CODE93,CODE128,EAN8,EAN13,ITF,UPC-A,UPC-E
     qrCode: true
     pdf417Code: true
     bitImageRaster: true


### PR DESCRIPTION
## Notes

* The list of supported codepages was assembled based on the printer's self-test print output.
* Tested using python-escpos (https://github.com/python-escpos/python-escpos), and everything seems to work except chaning codepages.
* Codepage changing most likely work only with the factory/vendor provided software.
* Only tested via USB interface.

## Printer Specification

The following product specification is taken from the product website:

> Product Specification
> ```
> | ----------------- | -------------------------------------------------------------------------------------------------------- |
> | Interfaces        | USB / USB + LAN / USB + BT / USB + BT + LAN + WIFI / USB + WIFI / etc                                    |
> | Print Comand      | ESC/POS                                                                                                  |
> | Print Method      | Thermal Line Printing                                                                                    |
> | Print Speed       | 200--220 mm/sec                                                                                          |
> | No. of Total Dots | 576 dots/line                                                                                            |
> | Auto Paper Cutter | Full or Partial cut                                                                                      |
> | Print Width       | 80 mm                                                                                                    |
> | Character Size    | Font A: 12 x 24 dots; Font B: 9 x 17 dots; Simplified/Traditional Chinese: 24 x 24 dots                  |
> | NV Flash          | 256 Kbytes                                                                                               |
> | Code              | 1D: UPC-1, UPC-E, JAN13 (EAN13), JAN8 (EAN8), CODE39, ITF, CODABAR, CODE93, CODE128; 2D: QR CODE, PDF417 |
> | Compatible OS     | Window; Linux; Android; iOS                                                                              |
> | ----------------- | -------------------------------------------------------------------------------------------------------- |
> ```
> 
> Paper & Electrical
> ```
> | ---------------------- | --------------------------------------------------------- |
> | Paper Type             | Roll Paper                                                |
> | Paper Width            | 79.5 mm plusminus 0.5 mm                                  |
> | Line Spacing           | 3.75 mm (adjustable by commands)                          |
> | Roll Diameter          | 83 mm                                                     |
> | Paper Thickness        | 0.06--0.08 mm                                             |
> | Power Adapter          | Input: AC: 100--240 V, 50--60 Hz; Output: DC 24 V / 1.5 A |
> | Cash Drawer Control    | 12 V / 1 A                                                |
> | Cutter Life            | 1.5 million cuts                                          |
> | Print Head Reliability | 100 km                                                    |
> | ---------------------- | --------------------------------------------------------- |
> ```
> 
> Physical & Environmental
> ```
> | ------------------ | ------------------------------------------------- |
> | Temperature        | -10--45 Celsius (work); -20--60 Celsius (storage) |
> | Humidity (working) | 10--90 %                                          |
> | Weight             | 0.8 Kg                                            |
> | Dimensions         | 130 mm x 160 mm x 122 mm (D x W x H)              |
> | ------------------ | ------------------------------------------------- |
> ```

## Printer Test Page

<img width="487" height="1591" alt="printer_test_page_50pct_redacted" src="https://github.com/user-attachments/assets/de071e8a-a45f-4cd0-85bf-101641084609" />

## Sources

* https://www.yhdaa.com/80mm-desktop-direct-thermal-receipt-printer-product/ (https://web.archive.org/web/20251222084821/https://www.yhdaa.com/80mm-desktop-direct-thermal-receipt-printer-product/)
* https://v6-file.globalso.com/upload/p/827/file/2025-01/8390-cd-files.zip
* https://manuals.plus/ae/1005008795505820
* https://www.alibaba.com/product-detail/YHD-8390-High-Speed-Auto-Cutter_1601305244352.html
