### PR TITLE
collate.py: open YAML inputs as UTF-8 so the build runs on Windows

### DIFF
--- a/scripts/collate.py
+++ b/scripts/collate.py
@@ -20,7 +20,7 @@ def load_encodings():
     Load in all the encodings from the encoding definition file
     """
     encoding_fn = os.path.dirname(__file__) + "/../data/encoding.yml"
-    encodings_raw = yaml.safe_load(open(encoding_fn).read())
+    encodings_raw = yaml.safe_load(open(encoding_fn, encoding="utf-8").read())
     return encodings_raw
 
 
@@ -34,7 +34,9 @@ def load_profiles():
         if not profile_fn[-3:] == "yml":
             continue
 
-        profile_dict = yaml.safe_load(open(profiles_dir + profile_fn).read())
+        profile_dict = yaml.safe_load(
+            open(profiles_dir + profile_fn, encoding="utf-8").read()
+        )
         # One item per file
         assert (
             len(profile_dict) == 1


### PR DESCRIPTION
`scripts/collate.py` opens its YAML inputs without an explicit encoding, so Python falls back to the locale code page `cp1252` on Windows, and the build dies immediately with `UnicodeDecodeError: 'charmap' codec can't decode byte 0x90` on `data/encoding.yml` (which contains UTF-8 character-map data: TCVN Vietnamese, Katakana, box drawing). 

This makes the build unrunnable on stock Windows. 

Fix: pass `encoding="utf-8"` to both input open() calls, matching the output writes which already encode UTF-8 explicitly. Workaround until merged: `python -X utf8 scripts/collate.py`.